### PR TITLE
Add InputStream.readline() for compat reasons

### DIFF
--- a/gevent_fastcgi/base.py
+++ b/gevent_fastcgi/base.py
@@ -213,6 +213,10 @@ class InputStream(object):
         self._eof_received.wait()
         return self._file.read(size)
 
+    def readline(self, size=-1):
+        self._eof_received.wait()
+        return self._file.readline(size)
+
     def readlines(self, sizehint=0):
         self._eof_received.wait()
         return self._file.readlines(sizehint)


### PR DESCRIPTION
While using `flask`, I found `werkzeug` would fail trying to call `readline()` member function on `InputStream` when I used `request.get_json()`. It's more than a few levels in.

I added the missing wrapper function. Sorry no test code.