### PR TITLE
Add Windows and Python 3 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ This project could not be where it is now without help of the following great pe
 
         * `David Galeano <https://github.com/davidgaleano>`_
         * `Lucas Clemente Vella <https://github.com/lvella>`_
+        * `Nicholas Kwan <https://github.com/multippt>`_
         * `Peter D. Gray <https://github.com/peter-conalgo>`_
 
 Thank you guys for all your help!

--- a/gevent_fastcgi/server.py
+++ b/gevent_fastcgi/server.py
@@ -31,7 +31,7 @@ import logging
 
 import atexit
 if os.name == "nt":
-    from signal import SIGTERM
+    from signal import SIGINT, SIGTERM
 else:
     from signal import SIGHUP, SIGKILL, SIGQUIT, SIGINT, SIGTERM
 
@@ -339,9 +339,9 @@ class FastCGIServer(StreamServer):
                 self._start_workers()
                 self._supervisor = spawn(self._watch_workers)
                 atexit.register(self._cleanup)
-                sig_register = [SIGTERM]
+                sig_register = [SIGTERM, SIGINT]
                 if os.name != "nt":
-                    sig_register.extend([SIGINT, SIGQUIT])
+                    sig_register.extend([SIGQUIT])
                 for signum in sig_register:
                     signal(signum, sys.exit, 1)
 

--- a/gevent_fastcgi/server.py
+++ b/gevent_fastcgi/server.py
@@ -259,6 +259,10 @@ class ConnectionHandler(six.with_metaclass(ConnectionHandlerType, object)):
             # EOF received
             request.environ = dict(unpack_pairs(request._environ.read()))
             del request._environ
+
+            # Unicode compatibility
+            for key in list(request.environ.keys()):
+                request.environ[key.decode("ISO-8859-1")] = request.environ[key].decode("ISO-8859-1")
             if request.role in (FCGI_RESPONDER, FCGI_AUTHORIZER):
                 self.spawn_request_handler(request)
 

--- a/gevent_fastcgi/speedups.c
+++ b/gevent_fastcgi/speedups.c
@@ -67,7 +67,11 @@ py_unpack_pairs(PyObject *self, PyObject *args) {
 			buf += nlen;
 			value = buf;
 			buf += vlen;
+			#if PY_MAJOR_VERSION >= 3
+			tuple = Py_BuildValue("(y#y#)", name, nlen, value, vlen);
+			#else
 			tuple = Py_BuildValue("(s#s#)", name, nlen, value, vlen);
+			#endif
 			if (tuple) {
 				PyList_Append(result, tuple);
 				Py_DECREF(tuple);

--- a/gevent_fastcgi/speedups.c
+++ b/gevent_fastcgi/speedups.c
@@ -22,8 +22,15 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#ifdef _WIN32
+#include <Winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
 
+#if PY_MAJOR_VERSION >= 3
+#define PyString_FromStringAndSize PyBytes_FromStringAndSize
+#endif
 
 #define ENSURE_LEN(req) if ((end - buf) < (req)) { \
 	Py_XDECREF(result); \
@@ -185,7 +192,54 @@ static PyMethodDef _methods[] = {
 	{NULL, NULL}
 };
 
+struct module_state {
+    PyObject *error;
+};
+
+#if PY_MAJOR_VERSION >= 3
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+#else
+#define GETSTATE(m) (&_state)
+static struct module_state _state;
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+
+static int _traverse(PyObject *m, visitproc visit, void *arg) {
+    Py_VISIT(GETSTATE(m)->error);
+    return 0;
+}
+
+static int _clear(PyObject *m) {
+    Py_CLEAR(GETSTATE(m)->error);
+    return 0;
+}
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "speedups",
+    NULL,
+    sizeof(struct module_state),
+    _methods,
+    NULL,
+    _traverse,
+    _clear,
+    NULL
+};
+
+#define INITERROR return NULL
 PyMODINIT_FUNC
-initspeedups(void) {
+PyInit_speedups(void)
+#else
+#define INITERROR return
+void
+initspeedups(void)
+#endif
+{
+#if PY_MAJOR_VERSION >= 3
+    PyObject *module = PyModule_Create(&moduledef);
+    return module;
+#else
 	Py_InitModule("speedups", _methods);
+#endif
 }

--- a/gevent_fastcgi/utils.py
+++ b/gevent_fastcgi/utils.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 
 import struct
 import logging
+import six
 
 
 __all__ = [
@@ -49,7 +50,7 @@ for name in 'header', 'begin_request', 'end_request', 'unknown_type':
 
 def pack_pairs(pairs):
     if isinstance(pairs, dict):
-        pairs = pairs.iteritems()
+        pairs = six.iteritems(pairs)
     return ''.join(pack_pair(name, value) for name, value in pairs)
 
 

--- a/gevent_fastcgi/utils.py
+++ b/gevent_fastcgi/utils.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 import struct
 import logging
 import six
+import sys
 
 
 __all__ = [
@@ -51,7 +52,7 @@ for name in 'header', 'begin_request', 'end_request', 'unknown_type':
 def pack_pairs(pairs):
     if isinstance(pairs, dict):
         pairs = six.iteritems(pairs)
-    return ''.join(pack_pair(name, value) for name, value in pairs)
+    return b''.join(pack_pair(name, value) for name, value in pairs)
 
 
 try:
@@ -65,17 +66,27 @@ except ImportError:
     def pack_len(s):
         l = len(s)
         if l < 128:
-            return chr(l)
+            if sys.version_info < (3, 0):
+                return chr(l)
+            else:
+                return bytes([l])
         elif l > 0x7fffffff:
             raise ValueError('Maximum name or value length is {0}'.format(
                 0x7fffffff))
         return length_struct.pack(l | 0x80000000)
 
     def pack_pair(name, value):
-        return ''.join((pack_len(name), pack_len(value), name, value))
+        if isinstance(name, six.text_type):
+            name = name.encode("ISO-8859-1")
+        if isinstance(value, six.text_type):
+            value = value.encode("ISO-8859-1")
+        return b''.join((pack_len(name), pack_len(value), name, value))
 
     def unpack_len(buf, pos):
-        _len = ord(buf[pos])
+        if sys.version_info < (3, 0):
+            _len = ord(buf[pos])
+        else:
+            _len = buf[pos]
         if _len & 128:
             _len = length_struct.unpack_from(buf, pos)[0] & 0x7fffffff
             pos += 4

--- a/gevent_fastcgi/wsgi.py
+++ b/gevent_fastcgi/wsgi.py
@@ -20,13 +20,14 @@
 
 from __future__ import absolute_import
 
+import six
 import sys
 import logging
 from traceback import format_exception
 import re
 from wsgiref.handlers import BaseCGIHandler
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from .interfaces import IRequestHandler
 from .server import Request, FastCGIServer
@@ -50,10 +51,8 @@ mandatory_environ = (
 )
 
 
+@implementer(IRequestHandler)
 class WSGIRefRequestHandler(object):
-
-    implements(IRequestHandler)
-
     def __init__(self, app):
         self.app = app
 
@@ -109,7 +108,7 @@ class WSGIRequest(object):
         if exc_info is not None:
             try:
                 if self._headers_sent:
-                    raise exc_info[0], exc_info[1], exc_info[2]
+                    six.reraise(exc_info[0], exc_info[1], exc_info[2])
             finally:
                 exc_info = None
 
@@ -152,11 +151,8 @@ class WSGIRequest(object):
         self._stdout.writelines(headers)
         self._headers_sent = True
 
-
+@implementer(IRequestHandler)
 class WSGIRequestHandler(object):
-
-    implements(IRequestHandler)
-
     def __init__(self, app):
         self.app = app
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,17 @@ setup(
             'wsgiref = gevent_fastcgi.adapters.paste_deploy:wsgiref_server_runner',
         ],
     },
+    classifiers=(
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Internet :: WWW/HTTP :: WSGI :: Server',
+    ),
     test_suite="tests",
     tests_require=['mock'],
     ext_modules=ext_modules

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,12 @@ from setuptools import setup, Extension, find_packages
 ext_modules = []
 # C speedups are no good for PyPy
 if '__pypy__' not in sys.builtin_module_names:
-    ext_modules.append(
-        Extension('gevent_fastcgi.speedups', ['gevent_fastcgi/speedups.c']))
+    if os.name == "nt":
+        ext_modules.append(
+            Extension('gevent_fastcgi.speedups', ['gevent_fastcgi/speedups.c'], libraries=["Ws2_32"]))
+    else:
+        ext_modules.append(
+            Extension('gevent_fastcgi.speedups', ['gevent_fastcgi/speedups.c']))
 
 setup(
     name='gevent-fastcgi',
@@ -30,8 +34,9 @@ setup(
     zip_safe=True,
     license='MIT',
     install_requires=[
-        "zope.interface",
+        "zope.interface>=3.8.0",
         "gevent>=0.13.6",
+        "six",
     ],
     entry_points={
         'paste.server_runner': [

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if '__pypy__' not in sys.builtin_module_names:
 
 setup(
     name='gevent-fastcgi',
-    version='1.0.2.1',
+    version='1.1.0.0',
     description='''FastCGI/WSGI client and server implemented using gevent
     library''',
     long_description='''

--- a/tests/base/test_input_stream.py
+++ b/tests/base/test_input_stream.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, with_statement
 
 import unittest
+from six.moves import xrange
 
 from gevent import Timeout
 
@@ -13,7 +14,7 @@ class InputStreamTests(unittest.TestCase):
     def setUp(self):
         self.sock = MockSocket()
         self.conn = Connection(self.sock)
-        self.stream = InputStream(self.conn)
+        self.stream = InputStream()
 
     def tearDown(self):
         del self.stream
@@ -56,8 +57,9 @@ class InputStreamTests(unittest.TestCase):
     def test_readlines(self):
         stream = self.stream
         data_in = [text_data() + '\r\n' for _ in xrange(13)]
-        map(stream.feed, data_in)
+        list(map(stream.feed, data_in))
         stream.feed('')
 
         data_out = stream.readlines()
+        data_out = [line.decode("ISO-8859-1") for line in data_out]
         assert data_out == data_in, data_out

--- a/tests/base/test_input_stream.py
+++ b/tests/base/test_input_stream.py
@@ -37,8 +37,9 @@ class InputStreamTests(unittest.TestCase):
     def test_iter(self):
         stream = self.stream
         data_in = [text_data() + '\r\n' for _ in xrange(17)]
+        data_in = [line.encode("ISO-8859-1") for line in data_in]
 
-        map(stream.feed, data_in)
+        list(map(stream.feed, data_in))
         stream.feed('')
 
         for line_in, line_out in zip(data_in, stream):

--- a/tests/base/test_output_stream.py
+++ b/tests/base/test_output_stream.py
@@ -49,7 +49,7 @@ class StreamTestsBase(object):
         stream = self.stream()
         data = [binary_data(1024, 1) for _ in range(13)]
 
-        map(stream.write, data)
+        list(map(stream.write, data))
 
         self.sock.flip()
 
@@ -114,7 +114,7 @@ class StreamTestsBase(object):
         # should receive EOF record
         record = self.conn.read_record()
         assert record.type == stream.record_type
-        assert record.content == ''
+        assert record.content == b''
         assert record.request_id == stream.request_id
 
         assert self.conn.read_record() is None

--- a/tests/base/test_output_stream.py
+++ b/tests/base/test_output_stream.py
@@ -12,6 +12,7 @@ from gevent_fastcgi.const import (
 )
 
 from gevent_fastcgi.base import Connection, StdoutStream, StderrStream
+from six.moves import xrange
 from ..utils import binary_data, text_data, MockSocket
 
 
@@ -71,7 +72,7 @@ class StreamTestsBase(object):
             assert record.type == stream.record_type
             assert record.request_id == stream.request_id
             received.append(record.content)
-        assert ''.join(received) == ''.join(data)
+        assert b''.join(received) == b''.join([data])
 
     def test_long_writelines(self):
         stream = self.stream()
@@ -86,7 +87,7 @@ class StreamTestsBase(object):
             assert record.type == stream.record_type
             assert record.request_id == stream.request_id
             received.append(record.content)
-        assert ''.join(received) == ''.join(data)
+        assert b''.join(received) == b''.join(data)
 
     def test_empty_write(self):
         conn = self.conn
@@ -149,8 +150,8 @@ class StderrStreamTests(StreamTestsBase, unittest.TestCase):
         self.sock.flip()
 
         data_in = ''.join(data)
-        data_out = ''.join(record.content for record in self.conn
+        data_out = b''.join(record.content for record in self.conn
                            if (record.type == stream.record_type
                                and record.request_id == stream.request_id))
 
-        assert data_in == data_out
+        assert data_in == data_out.decode("ISO-8859-1")

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -1,16 +1,17 @@
 from __future__ import absolute_import
 
 import sys
+import imp
 import unittest
 from itertools import product
 
 from gevent_fastcgi.utils import pack_pairs, unpack_pairs
 
 
-SHORT_STR = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+SHORT_STR = b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 MEDIUM_STR = SHORT_STR * 32
 LONG_STR = MEDIUM_STR * 32
-STRINGS = ('', SHORT_STR, MEDIUM_STR, LONG_STR)
+STRINGS = (b'', SHORT_STR, MEDIUM_STR, LONG_STR)
 
 
 class UtilsTests(unittest.TestCase):
@@ -21,7 +22,7 @@ class UtilsTests(unittest.TestCase):
         assert pairs == tuple(unpack_pairs(pack_pairs(pairs)))
 
     def test_too_long(self):
-        TOO_LONG_STR = LONG_STR * (0x7fffffff / len(LONG_STR) + 1)
+        TOO_LONG_STR = LONG_STR * int(0x7fffffff / len(LONG_STR) + 1)
         pairs = product(STRINGS, (TOO_LONG_STR,))
 
         for pair in pairs:
@@ -37,12 +38,12 @@ class NoSpeedupsUtilsTests(UtilsTests):
     def setUp(self):
         sys.modules['gevent_fastcgi.speedups'] = None
         if 'gevent_fastcgi.utils' in sys.modules:
-            sys.modules['gevent_fastcgi.utils'] = reload(
+            sys.modules['gevent_fastcgi.utils'] = imp.reload(
                 sys.modules['gevent_fastcgi.utils'])
 
     def tearDown(self):
         del sys.modules['gevent_fastcgi.speedups']
-        sys.modules['gevent_fastcgi.utils'] = reload(
+        sys.modules['gevent_fastcgi.utils'] = imp.reload(
             sys.modules['gevent_fastcgi.utils'])
 
 

--- a/tests/server/test_connection_handler.py
+++ b/tests/server/test_connection_handler.py
@@ -112,7 +112,7 @@ class ConnectionHandlerTests(unittest.TestCase):
         assert rec and unpack_end_request(rec.content)
 
         for stream in FCGI_STDOUT, FCGI_STDERR:
-            assert '' == read_stream(handler, stream, req_id)
+            assert b'' == read_stream(handler, stream, req_id)
 
     def test_abort_request(self):
         req_id = next_req_id()
@@ -138,7 +138,7 @@ class ConnectionHandlerTests(unittest.TestCase):
         assert rec and unpack_end_request(rec.content)
 
         for stream in FCGI_STDOUT, FCGI_STDERR:
-            assert '' == read_stream(handler, stream, req_id)
+            assert b'' == read_stream(handler, stream, req_id)
 
     def test_request_multiplexing(self):
         req_id = next_req_id()
@@ -169,7 +169,7 @@ class ConnectionHandlerTests(unittest.TestCase):
             assert rec and unpack_end_request(rec.content)
 
             for stream in FCGI_STDOUT, FCGI_STDERR:
-                assert '' == read_stream(handler, stream, r_id)
+                assert b'' == read_stream(handler, stream, r_id)
 
 
 # Helper functions
@@ -248,10 +248,13 @@ def read_stream(handler, rec_type, req_id):
 
         assert closed, 'Stream was not closed'
 
-        return ''.join(content)
+        return b''.join(content)
 
+c = count(1)
+def do_next():
+    return next(c)
 
-next_req_id = count(1).next
+next_req_id = do_next
 
 
 if __name__ == '__main__':

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -57,8 +57,14 @@ class ServerTests(unittest.TestCase):
     def test_address(self):
         unix_address = 'socket.{0}'.format(os.getpid())
         tcp_address = ('127.0.0.1', 47231)
-        for address in (tcp_address, unix_address):
-            with start_wsgi_server(address, num_workers=2):
+        addresses = (tcp_address, unix_address)
+        if os.name == "nt":
+            addresses = (tcp_address,)  # Windows do not support unix socket
+        for address in addresses:
+            num_workers = 2
+            if os.name == "nt":
+                num_workers = 1  # Windows do not support multiple processes
+            with start_wsgi_server(address, num_workers=num_workers):
                 with make_connection(address) as conn:
                     self._run_get_values(conn)
             # check if socket file was removed
@@ -189,7 +195,7 @@ class ServerTests(unittest.TestCase):
             assert response.request_status == FCGI_REQUEST_COMPLETE
             assert response.stdout.eof_received
             headers, body = response.parse()
-            assert headers.get('Status') == '200 OK', repr(headers)
+            assert headers.get(b'Status') == b'200 OK', repr(headers)
             assert body == data
 
     def test_failed_request(self):
@@ -205,7 +211,7 @@ class ServerTests(unittest.TestCase):
                                             app=app(exception=error))
         assert response.stdout.eof_received
         headers, body = response.parse()
-        assert headers.get('Status', '').startswith('500 ')
+        assert headers.get(b'Status', b'').startswith(b'500 ')
 
         request_id = 11
         request = [
@@ -231,6 +237,7 @@ class ServerTests(unittest.TestCase):
         headers, body = response.parse()
         assert len(body) == 0, repr(body)
 
+    @unittest.skipIf(os.name == "nt", "Test not supported on Windows")
     def test_restart_workers(self):
         from gevent import sleep
 
@@ -265,7 +272,7 @@ class ServerTests(unittest.TestCase):
             self.assertEquals(record.type, FCGI_GET_VALUES_RESULT)
             values = dict(unpack_pairs(record.content))
             for name in names:
-                self.assertIn(name, values)
+                self.assertIn(name.encode("ISO-8859-1") if isinstance(name, six.text_type) else name, values)
             done = True
 
     def _handle_one_request(self, request_id, records, **server_params):
@@ -277,7 +284,7 @@ class ServerTests(unittest.TestCase):
 
         with start_wsgi_server(**server_params) as server:
             with make_connection(server.address) as conn:
-                map(conn.write_record, records)
+                list(map(conn.write_record, records))
                 conn.done_writing()
                 for record in conn:
                     self.assertIn(record.request_id, responses)

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -4,6 +4,8 @@ import os
 import signal
 import unittest
 import logging
+import errno
+import six
 
 
 class Filter(logging.Filter):
@@ -60,7 +62,7 @@ class ServerTests(unittest.TestCase):
                 with make_connection(address) as conn:
                     self._run_get_values(conn)
             # check if socket file was removed
-            if isinstance(address, basestring):
+            if isinstance(address, six.string_types):
                 assert not os.path.exists(address)
 
     def test_role(self):
@@ -241,7 +243,7 @@ class ServerTests(unittest.TestCase):
             sleep(0.1)
             try:
                 os.kill(worker, 0)
-            except OSError, e:
+            except OSError as e:
                 assert e.errno == errno.ESRCH
             sleep(5)
             assert len(server._workers) == server.num_workers
@@ -291,4 +293,4 @@ class ServerTests(unittest.TestCase):
                     else:
                         self.fail('Unexpected record type %s' % record.type)
 
-        return responses.values()
+        return list(responses.values())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,13 @@
 from __future__ import absolute_import
 
 import errno
+import sys
 from random import random, randint, choice
-from string import digits, letters, punctuation
+from string import digits, punctuation
+try:
+    from string import ascii_letters as letters
+except ImportError:
+    from string import letters
 from functools import wraps
 from contextlib import contextmanager
 import logging
@@ -19,6 +24,8 @@ from gevent_fastcgi.const import (
 from gevent_fastcgi.base import Connection, InputStream
 from gevent_fastcgi.utils import pack_pairs
 from gevent_fastcgi.wsgi import WSGIServer
+import six
+from six.moves import xrange
 
 
 __all__ = (
@@ -59,7 +66,10 @@ def some_delay(delay=None):
     sleep(delay)
 
 
-_binary_source = map(chr, range(256))
+if sys.version_info < (3, 0):
+    _binary_source = map(chr, range(256))
+else:
+    _binary_source = list(map(lambda x: bytes([x]), range(256)))
 _text_source = letters + digits + punctuation
 
 
@@ -110,7 +120,7 @@ class WSGIApplication(object):
 
         if self.response is None:
             response = [stdin.read()] or self.data
-        elif isinstance(self.response, basestring):
+        elif isinstance(self.response, six.string_types):
             response = [self.response]
         else:
             response = self.response
@@ -132,7 +142,7 @@ class WSGIApplication(object):
 class TestingConnection(Connection):
 
     def write_record(self, record):
-        if isinstance(record, (int, long, float)):
+        if isinstance(record, six.integer_types + (float,)):
             sleep(record)
         else:
             super(TestingConnection, self).write_record(record)
@@ -140,7 +150,7 @@ class TestingConnection(Connection):
 
 @contextmanager
 def make_connection(address):
-    af = isinstance(address, basestring) and socket.AF_UNIX or socket.AF_INET
+    af = isinstance(address, six.string_types) and getattr(socket, "AF_UNIX", 0) or socket.AF_INET
     sock = socket.socket(af, socket.SOCK_STREAM)
     try:
         sock.connect(address)
@@ -174,9 +184,9 @@ def check_socket(callable):
 
 class MockSocket(object):
 
-    def __init__(self, data=''):
+    def __init__(self, data=b''):
         self.input = data
-        self.output = ''
+        self.output = b''
         self.exception = False
         self.closed = False
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -269,7 +269,7 @@ class Response(object):
         self.app_status = None
 
     def parse(self):
-        headers, body = self.stdout.read().split('\r\n\r\n', 1)
+        headers, body = self.stdout.read().split(b'\r\n\r\n', 1)
         headers = dict(
-            header.split(': ', 1) for header in headers.split('\r\n'))
+            header.split(b': ', 1) for header in headers.split(b'\r\n'))
         return headers, body


### PR DESCRIPTION
This change-set adds Python 3 support as well as basic Windows support.

To build on Windows the following steps can be taken:
1. Install MSVC compiler (2008 for Python 2, 2015+ for Python 3)
2. Run pip install or python setup.py build to build the extension

Limitations:
* Max number of process workers is 1 on Windows at this time